### PR TITLE
feat(database): Allow database seeder to work on Sqlite

### DIFF
--- a/database/seeds/WorldTablesSeeder.php
+++ b/database/seeds/WorldTablesSeeder.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Seeder;
+use Illuminate\Database\SQLiteConnection;
 
 class WorldTablesSeeder extends Seeder
 {
@@ -12,7 +13,12 @@ class WorldTablesSeeder extends Seeder
      */
     public function run()
     {
-        \DB::statement('SET FOREIGN_KEY_CHECKS=0');
+        if (DB::connection() instanceof SQLiteConnection) {
+            DB::statement('PRAGMA FOREIGN_KEYS=0');
+        } else {
+            DB::statement('SET FOREIGN_KEY_CHECKS=0');
+        }
+
         $this->call(WorldContinentsTableSeeder::class);
         $this->call(WorldContinentsLocaleTableSeeder::class);
         $this->call(WorldCountriesTableSeeder::class);
@@ -21,6 +27,11 @@ class WorldTablesSeeder extends Seeder
         $this->call(WorldDivisionsLocaleTableSeeder::class);
         $this->call(WorldCitiesTableSeeder::class);
         $this->call(WorldCitiesLocaleTableSeeder::class);
-        \DB::statement('SET FOREIGN_KEY_CHECKS=1');
+
+        if (DB::connection() instanceof SQLiteConnection) {
+            DB::statement('PRAGMA FOREIGN_KEYS=1');
+        } else {
+            DB::statement('SET FOREIGN_KEY_CHECKS=1');
+        }
     }
 }


### PR DESCRIPTION
Sqlite has a different syntax for enabling and disabling foreign key
checks.