### PR TITLE
Disable Foreign Key for Postgres

### DIFF
--- a/database/seeds/WorldTablesSeeder.php
+++ b/database/seeds/WorldTablesSeeder.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Database\PostgresConnection;
 use Illuminate\Database\Seeder;
 use Illuminate\Database\SQLiteConnection;
 
@@ -14,6 +15,8 @@ class WorldTablesSeeder extends Seeder
     {
         if (DB::connection() instanceof SQLiteConnection) {
             DB::statement('PRAGMA FOREIGN_KEYS=0');
+        } elseif (DB::connection() instanceof PostgresConnection) {
+            DB::statement("SET session_replication_role = 'replica';");
         } else {
             DB::statement('SET FOREIGN_KEY_CHECKS=0');
         }
@@ -30,6 +33,8 @@ class WorldTablesSeeder extends Seeder
 
         if (DB::connection() instanceof SQLiteConnection) {
             DB::statement('PRAGMA FOREIGN_KEYS=1');
+        } elseif (DB::connection() instanceof PostgresConnection) {
+            DB::statement("SET session_replication_role = 'origin';");
         } else {
             DB::statement('SET FOREIGN_KEY_CHECKS=1');
         }


### PR DESCRIPTION
Handle the following error with postgres:

```
Illuminate/Database/QueryException with message 'SQLSTATE[42704]: Undefined object: 7 ERROR:  unrecognized configuration parameter "foreign_key_checks" (SQL: SET FOREIGN_KEY_CHECKS=0)'
```