### PR TITLE
Update WorldDivisionsTableSeeder.php

### DIFF
--- a/database/seeds/WorldDivisionsLocaleTableSeeder.php
+++ b/database/seeds/WorldDivisionsLocaleTableSeeder.php
@@ -2345,7 +2345,7 @@ class WorldDivisionsLocaleTableSeeder extends Seeder
                 'full_name' => NULL,
                 'id' => 233,
                 'locale' => 'en',
-                'name' => 'Canberra',
+                'name' => 'Australian Capital Territory',
             ),
             233 => 
             array (

--- a/database/seeds/WorldDivisionsTableSeeder.php
+++ b/database/seeds/WorldDivisionsTableSeeder.php
@@ -1023,7 +1023,7 @@ class WorldDivisionsTableSeeder extends Seeder
                 'full_name' => NULL,
                 'has_city' => 1,
                 'id' => 112,
-                'name' => 'Canberra',
+                'name' => 'Australian Capital Territory',
             ),
             112 => 
             array (


### PR DESCRIPTION
The ACT division in australia is actually called Australian Capital Territory, and Canberra is the city