### PR TITLE
Provide support for Laravel 8 through 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "require": {
         "php": ">7.3|^8.0",
-        "laravel/framework" : "^8.0|^9.0"
+        "laravel/framework" : "^8.0|^9.0|^10.0|^11.0|^12.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",


### PR DESCRIPTION
Change of allowed Laravel version to provide support for versions 8 through 12. 

Resolves issues #54, #60, #62, #64, #65

Cancels PR #60